### PR TITLE
updating dependency

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node_chromium_revision=830000

--- a/README.md
+++ b/README.md
@@ -127,10 +127,12 @@ Result is some sort of status confirmation reporting success or failure.
 
 
 #### /rest/jobs/<id>/data/
+
 URL for getting the data (or URLs to data) needed to start processing.
 
 
 #### /rest/jobs/<id>/claim/
+
 URL for claiming a job. Some sort of authentication might be implemeted, such
 as only allowing claims where a proper key is supplied via e.g. ?key=.
 
@@ -144,6 +146,7 @@ be claimed, otherwise some negative confirmation/http status code.
 
 
 #### /rest/jobs/<id>/lock/
+
 URL for locking a job, e.g. when claimed. Some sort of authentication might be
 implemeted, such as only allowing locking where a proper key is supplied via
 e.g. ?key=.
@@ -154,6 +157,7 @@ Result is some sort of status confirmation reporting success or failure.
 
 
 #### /rest/jobs/<id>/unlock/
+
 URL for unlocking a job, e.g. when the Worker that claimed it is suspected to
 have crashed. Some sort of authentication might be implemeted, such as only
 allowing claims where a proper key is supplied via e.g. ?key=.
@@ -164,6 +168,7 @@ Result is some sort of status confirmation reporting success or failure.
 
 
 #### /rest/jobs/<id>/deliver/
+
 URL for delivering a job, e.g. when claimed. Some sort of authentication might
 be implemeted, such as only allowing claims where a proper key is supplied via
 e.g. ?key=.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,6 +1,9 @@
 // Karma configuration
 // Generated on Tue May 30 2017 17:11:30 GMT+0200 (CEST)
 //
+
+process.env.CHROME_BIN = "node_modules/chromium/lib/chromium/chrome-linux/chrome";
+
 module.exports = (config) => {
     config.set({
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "Molflow",
   "license": "ISC",
   "devDependencies": {
-    "chromedriver": "^87.0.5",
+    "chromedriver": "^89.0.0",
     "chromium": "^3.0.2",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "author": "Molflow",
   "license": "ISC",
   "devDependencies": {
+    "chromedriver": "^87.0.5",
+    "chromium": "^3.0.2",
     "eslint": "^5.10.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jasmine": "^3.3.1",
     "jasmine-core": "^3.3.0",
     "junit": "^1.4.9",
-    "karma": "^6.2.0",
+    "karma": "^5.2.2",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",
     "karma-jasmine": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "jasmine": "^3.3.1",
     "jasmine-core": "^3.3.0",
     "junit": "^1.4.9",
-    "karma": "^1.7.0",
+    "karma": "^6.2.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",
     "karma-jasmine": "^2.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ greenlet==0.4.15          # via gevent
 gunicorn==20.0.4          # via -r requirements.in
 idna==2.9                 # via requests
 itsdangerous==1.1.0       # via flask
-jinja2==2.11.2            # via flask
+jinja2==2.11.3            # via flask
 jsl==0.2.4                # via -r requirements.in
 jsonschema==3.2.0         # via -r requirements.in
 markupsafe==1.1.1         # via jinja2

--- a/src/test/test_browser.py
+++ b/src/test/test_browser.py
@@ -7,9 +7,18 @@ class TestBrowser:
 
     @pytest.fixture
     def chrome(self):
-        driver = webdriver.Chrome()
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.binary_location = (
+            './node_modules/chromium/lib/chromium/chrome-linux/chrome'
+        )
+        chrome_options.add_argument('--headless')
+        chrome_options.add_argument('--no-sandbox')
+        driver = webdriver.Chrome(
+            './node_modules/chromedriver/bin/chromedriver',
+            options=chrome_options
+        )
+        driver.implicitly_wait(4)
         yield driver
-        driver.quit()
 
     def test_main_page_is_up(self, microq_service, chrome):
         """Test that main page is up"""

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ sitepackages=true
 basepython=python3.8
 whitelist_externals=
         xvfb-run
-        chromedriver
         docker-compose
 deps=
 	-rrequirements.txt


### PR DESCRIPTION
updating dependency and trying to fix browser test. now we use npm for pulling in cromedriver and browser, and using the .npmrc file to specify what revision of chrome browser to use. this is needed as the latest driver and browser that npm otherwise pulls does not play with each other. 